### PR TITLE
Add AppVeyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,67 @@
+# .appveyor.yml
+
+# Build version
+version: '1.5.6.{build}'
+
+# Use the latest available toolchain
+image: Visual Studio 2019
+
+# fetch repository as zip archive
+shallow_clone: true
+
+# PRs do not increment the build number
+pull_requests:
+  do_not_increment_build_number: true
+
+# Environment variables
+environment:
+  global:
+    # See http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    # See https://docs.microsoft.com/en-us/dotnet/core/tools/telemetry#how-to-opt-out
+    DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+# Build profiles
+configuration:
+  - Debug
+  - Release
+
+# Inherit AppVeyor version in the built artifacts
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+
+# Run these scripts before starting build
+before_build:
+  # Ensure project dependencies are fetched
+  - nuget restore
+
+# Build configuration
+build:
+  verbosity: minimal
+
+# Do not run unit tests
+test: off
+
+# Package artifacts
+artifacts:
+  - path: .dist\Build\Debug
+    name: 7thHeaven-v${appveyor_build_version}_debug
+    type: zip
+  - path: .dist\Build\Release
+    name: 7thHeaven-v${appveyor_build_version}
+    type: zip
+
+# Create a GitHub release for every tag
+deploy:
+  - provider: GitHub
+    tag: ${appveyor_repo_tag_name}
+    release: 7thHeaven-v${appveyor_build_version}
+    artifact: 7thHeaven-v${appveyor_build_version}_debug,7thHeaven-v${appveyor_build_version}
+    auth_token:
+      secure: EQV5fVmJb7YrL7MG34/iTjaEe7K+UKhF1io4nljqwdpq0+pwLX461kH5Ha2xsw7r
+    on:
+      appveyor_repo_tag: true

--- a/7thHeaven.Code/7thHeaven.Code.csproj
+++ b/7thHeaven.Code/7thHeaven.Code.csproj
@@ -18,7 +18,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Build\Debug\</OutputPath>
+    <OutputPath>..\.dist\Build\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -28,7 +28,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\Build\Release\</OutputPath>
+    <OutputPath>..\.dist\Build\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/7thWorkshop/7thHeaven.csproj
+++ b/7thWorkshop/7thHeaven.csproj
@@ -37,7 +37,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Build\Debug\</OutputPath>
+    <OutputPath>..\.dist\Build\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -47,7 +47,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\Build\Release\</OutputPath>
+    <OutputPath>..\.dist\Build\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/7thWrapperLib/7thWrapperLib.csproj
+++ b/7thWrapperLib/7thWrapperLib.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Build\Debug\</OutputPath>
+    <OutputPath>..\.dist\Build\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -30,7 +30,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\Build\Release\</OutputPath>
+    <OutputPath>..\.dist\Build\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/IrosArc/IrosArc.csproj
+++ b/IrosArc/IrosArc.csproj
@@ -34,7 +34,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Build\Debug\</OutputPath>
+    <OutputPath>..\.dist\Build\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -45,7 +45,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\Build\Release\</OutputPath>
+    <OutputPath>..\.dist\Build\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/IrosMega/IrosMega.csproj
+++ b/IrosMega/IrosMega.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Build\Debug\</OutputPath>
+    <OutputPath>..\.dist\Build\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -29,7 +29,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\Build\Release\</OutputPath>
+    <OutputPath>..\.dist\Build\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/TestPlugin/TestPlugin.csproj
+++ b/TestPlugin/TestPlugin.csproj
@@ -18,7 +18,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Build\Debug\</OutputPath>
+    <OutputPath>..\.dist\Build\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\Build\Release\</OutputPath>
+    <OutputPath>..\.dist\Build\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Updater/Updater.csproj
+++ b/Updater/Updater.csproj
@@ -34,7 +34,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Build\Debug\</OutputPath>
+    <OutputPath>..\.dist\Build\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -44,7 +44,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\Build\Release\</OutputPath>
+    <OutputPath>..\.dist\Build\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/build7H.bat
+++ b/build7H.bat
@@ -1,5 +1,5 @@
 set SLN="7thWrapperSln.sln"
-set BUILD="..\Build"
+set BUILD=".dist\Build"
 
 
 devenv /clean Debug %SLN%


### PR DESCRIPTION
**How to configure:**
1. Open https://ci.appveyor.com/signup/free and click on Github button
2. Open https://ci.appveyor.com/projects/new and choose this repository on the Github list
3. Replace `auth_token` for Github [with your own](https://github.com/settings/tokens) ( `public_repo` is enough ) with the encrypted value obtained from here: https://ci.appveyor.com/tools/encrypt ( paste your token in the page and use the encrypted value in the YAML replacing mine )
4. Add and push the new tag
5. Enjoy!

**Example:**
See https://github.com/julianxhokaxhiu/7h/releases/tag/1.5.6

**How do the binaries inherit the version?**
The `version` field in the YAML is the one which governs the overall build version. By changing that you will update it for the entire build. The way Veyor works unfortunately can't make it inherit from the Tag name. And even if it would have worked, when you create a normal build ( not created from a tag push ) that it would create a weird version. Therefore the smartest way I found was using the native .NET binary version, using the build part inherited from the CI build number.

By default, it will increase everytime a new tag will trigger a push. On PRs it will stay the same, but they will append the commit hash. Although no new deployment will be triggered.

**What does it brings:**
This PR adds the capability to automatically build your repository and provide release artifacts as soon as you create a tag. By default it will build a Debug and Release artifact and both will be added to the release. I think personally that both are useful for various purposes:
- I may want to report you a stack trace if it crashes so I'll use the debug version
- I want to not waste disk space so I'll use the release version

Of course to ensure your configuration works, you need to merge this PR first.
If you need support in configuring this let me know!

I hope you will appreciate this.