### PR TITLE
Switch SharpCompress dependency from NuGet to Submodule

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,6 +37,7 @@ assembly_info:
 # Run these scripts before starting build
 before_build:
   # Ensure project dependencies are fetched
+  - git submodule update --init --recursive
   - nuget restore
 
 # Build configuration

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SharpCompress"]
+	path = SharpCompress
+	url = https://github.com/adamhathcock/sharpcompress.git

--- a/7thHeaven.Code/7thHeaven.Code.csproj
+++ b/7thHeaven.Code/7thHeaven.Code.csproj
@@ -70,6 +70,10 @@
       <Project>{f80db232-4102-4249-8b31-2ddd5c7fa404}</Project>
       <Name>7thWrapperLib</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SharpCompress\src\SharpCompress\SharpCompress.csproj">
+      <Project>{8c6b794e-f8b2-45b2-a8d2-7ac73e967d80}</Project>
+      <Name>SharpCompress</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Workshop.resx">
@@ -79,11 +83,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Loader.gif" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="SharpCompress">
-      <Version>0.23.0</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/7thWorkshop/7thHeaven.csproj
+++ b/7thWorkshop/7thHeaven.csproj
@@ -340,6 +340,10 @@
       <Project>{37F83EE9-4D31-4CD5-9190-1BB31886BA5C}</Project>
       <Name>IrosMega</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SharpCompress\src\SharpCompress\SharpCompress.csproj">
+      <Project>{8c6b794e-f8b2-45b2-a8d2-7ac73e967d80}</Project>
+      <Name>SharpCompress</Name>
+    </ProjectReference>
     <ProjectReference Include="..\TurBoLog\TurBoLog.csproj">
       <Project>{03eede27-0abb-4cda-a7f2-f746e2083202}</Project>
       <Name>TurBoLog</Name>
@@ -400,9 +404,6 @@
     </PackageReference>
     <PackageReference Include="NVorbis">
       <Version>0.8.6</Version>
-    </PackageReference>
-    <PackageReference Include="SharpCompress">
-      <Version>0.23.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/7thWrapperLib/7thWrapperLib.csproj
+++ b/7thWrapperLib/7thWrapperLib.csproj
@@ -93,9 +93,12 @@
     <PackageReference Include="NAudio">
       <Version>1.9.0</Version>
     </PackageReference>
-    <PackageReference Include="SharpCompress">
-      <Version>0.23.0</Version>
-    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SharpCompress\src\SharpCompress\SharpCompress.csproj">
+      <Project>{8c6b794e-f8b2-45b2-a8d2-7ac73e967d80}</Project>
+      <Name>SharpCompress</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/7thWrapperSln.sln
+++ b/7thWrapperSln.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "7thHeaven.Code", "7thHeaven
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TurBoLog", "TurBoLog\TurBoLog.csproj", "{03EEDE27-0ABB-4CDA-A7F2-F746E2083202}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpCompress", "SharpCompress\src\SharpCompress\SharpCompress.csproj", "{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -196,6 +198,26 @@ Global
 		{03EEDE27-0ABB-4CDA-A7F2-F746E2083202}.Release|x64.Build.0 = Release|Any CPU
 		{03EEDE27-0ABB-4CDA-A7F2-F746E2083202}.Release|x86.ActiveCfg = Release|Any CPU
 		{03EEDE27-0ABB-4CDA-A7F2-F746E2083202}.Release|x86.Build.0 = Release|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Debug|Win32.Build.0 = Debug|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Debug|x64.Build.0 = Debug|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Debug|x86.Build.0 = Debug|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Release|Win32.ActiveCfg = Release|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Release|Win32.Build.0 = Release|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Release|x64.ActiveCfg = Release|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Release|x64.Build.0 = Release|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Release|x86.ActiveCfg = Release|Any CPU
+		{8C6B794E-F8B2-45B2-A8D2-7AC73E967D80}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/IrosArc/IrosArc.csproj
+++ b/IrosArc/IrosArc.csproj
@@ -93,9 +93,10 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SharpCompress">
-      <Version>0.23.0</Version>
-    </PackageReference>
+    <ProjectReference Include="..\SharpCompress\src\SharpCompress\SharpCompress.csproj">
+      <Project>{8c6b794e-f8b2-45b2-a8d2-7ac73e967d80}</Project>
+      <Name>SharpCompress</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/TestPlugin/TestPlugin.csproj
+++ b/TestPlugin/TestPlugin.csproj
@@ -51,11 +51,10 @@
       <Project>{f80db232-4102-4249-8b31-2ddd5c7fa404}</Project>
       <Name>7thWrapperLib</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="SharpCompress">
-      <Version>0.23.0</Version>
-    </PackageReference>
+    <ProjectReference Include="..\SharpCompress\src\SharpCompress\SharpCompress.csproj">
+      <Project>{8c6b794e-f8b2-45b2-a8d2-7ac73e967d80}</Project>
+      <Name>SharpCompress</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Updater/Updater.csproj
+++ b/Updater/Updater.csproj
@@ -114,9 +114,10 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SharpCompress">
-      <Version>0.23.0</Version>
-    </PackageReference>
+    <ProjectReference Include="..\SharpCompress\src\SharpCompress\SharpCompress.csproj">
+      <Project>{8c6b794e-f8b2-45b2-a8d2-7ac73e967d80}</Project>
+      <Name>SharpCompress</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
It seems that the NuGet provided one is only for x64, while we do need the x86.
Importing it as another project and building it as a dependency works just fine.