### PR TITLE
Improve CreateFileW API handling

### DIFF
--- a/7thWorkshop/fLibrary.cs
+++ b/7thWorkshop/fLibrary.cs
@@ -1220,7 +1220,11 @@ They will be automatically turned off.";
             string ff7folder = System.IO.Path.GetDirectoryName(Sys.Settings.FF7Exe);
             string data = System.IO.Path.Combine(ff7folder, "data");
             _7thWrapperLib.RuntimeProfile rp = new _7thWrapperLib.RuntimeProfile() {
-                MonitorPaths = new List<string>() { data, Sys.Settings.AaliFolder, Sys.Settings.MovieFolder,},
+                MonitorPaths = new List<string>() {
+                    data,
+                    Sys.Settings.AaliFolder,
+                    Sys.Settings.MovieFolder,
+                },
                 ModPath = Sys.Settings.LibraryLocation,
                 OpenGLConfig = Sys.ActiveProfile.OpenGLConfig,
                 FF7Path = ff7folder,
@@ -1230,7 +1234,7 @@ They will be automatically turned off.";
                     .ToList()
             };
 
-            rp.MonitorPaths.AddRange(Sys.Settings.ExtraFolders.Select(s => System.IO.Path.Combine(ff7folder, s)));
+            rp.MonitorPaths.AddRange(Sys.Settings.ExtraFolders.Where(s => s.Length > 0).Select(s => System.IO.Path.Combine(ff7folder, s)));
 
 
             if (varDump) {


### PR DESCRIPTION
A better way to handle file patching, by touching only files that are part of the game.

Also, if the Extra Paths had a new line inside it was considered as a "third path" forcing 7h to "double-patch" them in memory. By reducing the set, we now ensure they are only touched once, by checking if extra paths are actually a valid path.