### PR TITLE
Fix crash on Activate or Activate All mods.

### DIFF
--- a/7thHeaven.Code/Library.cs
+++ b/7thHeaven.Code/Library.cs
@@ -77,6 +77,7 @@ namespace Iros._7th.Workshop {
             DefaultUpdate = UpdateType.Notify;
             Items = new List<InstalledItem>();
             PendingDelete = new List<string>();
+            CodeAllowed = new List<Guid>();
         }
     }
 


### PR DESCRIPTION
On 1st run, the 1st time you try to activate a mod, it will crash with null exception on the list due to this code piece missing from the library.