### PR TITLE
Fix #58

### DIFF
--- a/7thWorkshop/fLibrary.cs
+++ b/7thWorkshop/fLibrary.cs
@@ -19,6 +19,7 @@ using System.Diagnostics;
 //using SharpCompress.Reader;
 using TurBoLog.UI;
 using System.Threading;
+using System.IO;
 
 namespace Iros._7th.Workshop {
     public partial class fLibrary : Form {
@@ -1228,6 +1229,7 @@ They will be automatically turned off.";
                 ModPath = Sys.Settings.LibraryLocation,
                 OpenGLConfig = Sys.ActiveProfile.OpenGLConfig,
                 FF7Path = ff7folder,
+                gameFiles = Directory.GetFiles(ff7folder, "*.*", SearchOption.AllDirectories),
                 Mods = Sys.ActiveProfile.Items
                     .Select(i => i.GetRuntime(_context))
                     .Where(i => i != null)

--- a/7thWrapperLib/Profile.cs
+++ b/7thWrapperLib/Profile.cs
@@ -98,6 +98,7 @@ namespace _7thWrapperLib {
         public RuntimeOptions Options { get; set; }
         public string ModPath { get; set; }
         public string FF7Path { get; set; }
+        public string[] gameFiles {get; set; }
         public List<string> MonitorPaths { get; set; }
 
         public List<RuntimeMod> Mods { get; set; }

--- a/7thWrapperLib/Wrap.cs
+++ b/7thWrapperLib/Wrap.cs
@@ -488,11 +488,11 @@ namespace _7thWrapperLib {
 
 
             bool result = Win32.WriteFile(hFile, lpBuffer, nNumberOfBytesToWrite, out lpNumberOfBytesWritten, ref lpOverlapped);
-            System.Diagnostics.Debug.WriteLine(String.Format("Write {0} bytes on {1}", lpNumberOfBytesWritten, hFile.ToInt32()));
+            //System.Diagnostics.Debug.WriteLine(String.Format("Write {0} bytes on {1}", lpNumberOfBytesWritten, hFile.ToInt32()));
 
             if (_saveFiles.ContainsKey(hFile)) {
                 int offset = SetFilePointer(hFile, 0, IntPtr.Zero, EMoveMethod.Current);
-                System.Diagnostics.Debug.WriteLine(String.Format("Write {0} bytes to {1} at offset {2}", lpNumberOfBytesWritten, _saveFiles[hFile], offset));
+                //System.Diagnostics.Debug.WriteLine(String.Format("Write {0} bytes to {1} at offset {2}", lpNumberOfBytesWritten, _saveFiles[hFile], offset));
             }
 
             return result;
@@ -584,9 +584,15 @@ namespace _7thWrapperLib {
             [MarshalAs(UnmanagedType.U4)] FileAttributes dwFlagsAndAttributes,
             IntPtr hTemplateFile) {
 
+            // Usually this check should be enough...
             bool isFF7GameFile = lpFileName.StartsWith(_profile.FF7Path, StringComparison.InvariantCultureIgnoreCase);
+            // ...but if it fails, last resort is to check if the file exists in the game directory
+            if (!isFF7GameFile && !lpFileName.StartsWith("\\", StringComparison.InvariantCultureIgnoreCase) && !Path.IsPathRooted(lpFileName))
+            {
+                isFF7GameFile = _profile.gameFiles.Any(s => s.EndsWith(lpFileName, StringComparison.InvariantCultureIgnoreCase));
+            }
 
-            // Patch only FF7 Game files
+            // If a game file is found, process with replacing its content with relative mod file
             if (isFF7GameFile)
             {
                 lpFileName = lpFileName.Replace("\\/", "\\").Replace("/", "\\").Replace("\\\\", "\\");
@@ -613,9 +619,10 @@ namespace _7thWrapperLib {
                                 return CreateVA(mapped);
                     }
                 }
-            }
+            } else
+                System.Diagnostics.Debug.WriteLine("Skipped file {0}{1}", "", lpFileName);
 
-			IntPtr handle = CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+            IntPtr handle = CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
 			//System.Diagnostics.Debug.WriteLine("Hooked CreateFileW for {0} under {1}", lpFileName, handle.ToInt32());
 
             if (isFF7GameFile && handle.ToInt32() != -1)


### PR DESCRIPTION
If the desired path to be opened does not contain the game directory inside of it, the file is usually skipped.
This patch now matches these kind of files to the game directory contents. If there is a match, it's definitely a game file.